### PR TITLE
fix(leading-zeros): math validation problem with a leading zero, when the response and the correct answer also have matching trailing zeros

### DIFF
--- a/src/conversion/latex-to-ast.ts
+++ b/src/conversion/latex-to-ast.ts
@@ -1146,7 +1146,7 @@ export class LatexToAst {
       if (parsedNumber !== number.toString()) {
         const p = number.toString();
         // @ts-ignore
-        const sub = result
+        const sub = parsedNumber
           // @ts-ignore
           .substring(p.length)
           .split("")

--- a/src/fixtures/latex-equal/literal/literal.ts
+++ b/src/fixtures/latex-equal/literal/literal.ts
@@ -15,9 +15,20 @@ export default {
       opts: { literal: { allowTrailingZeros: true } },
     },
     {
-      only:true,
       target: "0.500",
       eq: [".500000"],
+      opts: { literal: { allowTrailingZeros: true } },
+      ne: [".5001"],
+    },
+    {
+      target: "0.500",
+      ne: [".500000"],
+      opts: { literal: { allowTrailingZeros: false } },
+    },
+    {
+      target: "0.500",
+      eq: [".500"],
+      opts: { literal: { allowTrailingZeros: true } },
       ne: [".5001"],
     },
     {

--- a/src/fixtures/latex-equal/literal/literal.ts
+++ b/src/fixtures/latex-equal/literal/literal.ts
@@ -1,4 +1,5 @@
 export default {
+
   mode: "literal",
   tests: [
     {
@@ -12,6 +13,12 @@ export default {
       eq: ["12.000000"],
       ne: ["12.001"],
       opts: { literal: { allowTrailingZeros: true } },
+    },
+    {
+      only:true,
+      target: "0.500",
+      eq: [".500000"],
+      ne: [".5001"],
     },
     {
       target: "12.00",

--- a/src/latex-equal.ts
+++ b/src/latex-equal.ts
@@ -26,11 +26,9 @@ export const latexEqual = (a: Latex, b: Latex, opts: Opts) => {
   }
 
   const al = lta.convert(a);
-  console.log(al, "al")
-
 
   const bl = lta.convert(b);
-  console.log(bl, "bl")
+
   if (differenceIsTooGreat(al, bl)) {
     return false;
   }


### PR DESCRIPTION
- add tests
- cleanup
- eg: 0.50 does not match at this point .50